### PR TITLE
Check for permission via role.

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -79,6 +79,10 @@ class PermissionServiceProvider extends ServiceProvider
             $bladeCompiler->directive('endhasallroles', function () {
                 return '<?php endif; ?>';
             });
+            $bladeCompiler->directive('permissionviarole', function ($permission) {
+                $allPermissions = (array) Auth::user()->getPermissionsViaRoles();
+                return in_array($permission, $allPermissions);
+            });
         });
     }
 }


### PR DESCRIPTION
The @can method is great to check for permissions that are directly assigned to the specific user, however it does not check for permissions via a role. This simple bit adds that into the blade functionality.